### PR TITLE
Convert to Spigot 1.8.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,16 +9,16 @@
 
     <repositories>
         <repository>
-            <id>yawkat</id>
-            <url>http://mvn.yawk.at/</url>
+            <id>spigot-repo</id>
+            <url>http://hub.spigotmc.org/nexus/content/groups/public</url>
         </repository>
     </repositories>
 
     <dependencies>
         <dependency>
             <groupId>org.spigotmc</groupId>
-            <artifactId>spigot</artifactId>
-            <version>1.8-R0.1-SNAPSHOT</version>
+            <artifactId>spigot-api</artifactId>
+            <version>1.8.3-R0.1-SNAPSHOT</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Spigot 1.8.3 is out, you should really convert
